### PR TITLE
add denoUnstable flag to DenoWorkerOptions

### DIFF
--- a/src/DenoWorker.spec.ts
+++ b/src/DenoWorker.spec.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { URL } from 'url';
 import { MessageChannel, MessagePort } from './MessageChannel';
 import psList from 'ps-list';
+import child_process, { spawn } from 'child_process';
 
 console.log = jest.fn();
 jest.setTimeout(10000);
@@ -111,6 +112,32 @@ describe('DenoWorker', () => {
                 type: 'echo',
                 message: 'Hello',
             });
+        });
+
+        it('should allow usage of the --unstable flag', async () => {
+            const spawnSpy = jest.spyOn(child_process, 'spawn');
+
+            worker = new DenoWorker(echoScript, { denoUnstable: true });
+
+            let ret: any;
+            let resolve: any;
+            let promise = new Promise((res, rej) => {
+                resolve = res;
+            });
+            worker.onmessage = (e) => {
+                ret = e.data;
+                resolve();
+            };
+
+            worker.postMessage({
+                type: 'echo',
+                message: 'Hello',
+            });
+
+            await promise;
+
+            const call = spawnSpy.mock.calls[0];
+            expect(call[1]).toContain('--unstable');
         });
     });
 

--- a/src/DenoWorker.spec.ts
+++ b/src/DenoWorker.spec.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { URL } from 'url';
 import { MessageChannel, MessagePort } from './MessageChannel';
 import psList from 'ps-list';
-import child_process, { spawn } from 'child_process';
+import child_process from 'child_process';
 
 console.log = jest.fn();
 jest.setTimeout(10000);
@@ -119,13 +119,11 @@ describe('DenoWorker', () => {
 
             worker = new DenoWorker(echoScript, { denoUnstable: true });
 
-            let ret: any;
             let resolve: any;
             let promise = new Promise((res, rej) => {
                 resolve = res;
             });
             worker.onmessage = (e) => {
-                ret = e.data;
                 resolve();
             };
 
@@ -137,7 +135,8 @@ describe('DenoWorker', () => {
             await promise;
 
             const call = spawnSpy.mock.calls[0];
-            expect(call[1]).toContain('--unstable');
+            const [_deno, args] = call;
+            expect(args).toContain('--unstable');
         });
     });
 

--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -56,6 +56,11 @@ export interface DenoWorkerOptions {
     logStderr: boolean;
 
     /**
+     * Whether to use Deno's unstable features
+     */
+    denoUnstable: boolean;
+
+    /**
      * The permissions that the Deno worker should use.
      */
     permissions: {
@@ -152,6 +157,7 @@ export class DenoWorker {
                 reload: process.env.NODE_ENV !== 'production',
                 logStdout: true,
                 logStderr: true,
+                denoUnstable: false,
                 permissions: {},
             },
             options || {}
@@ -242,7 +248,7 @@ export class DenoWorker {
             let runArgs = [] as string[];
 
             addOption(runArgs, '--reload', this._options.reload);
-            // addOption(runArgs, '--unstable', true);
+            addOption(runArgs, '--unstable', this._options.denoUnstable);
 
             if (this._options.permissions) {
                 addOption(


### PR DESCRIPTION
Hello!

I was using your library and found myself wanting the unstable flag. I noticed support was present, but commented out, so I went ahead and added a worker option to enable it.

A note about testing:
I have verified this works locally, but have not written any tests yet. I have not yet found a way during runtime to confirm that Deno is running with unstable features aside from attempting to use them. This seemed like a strategy for flaky tests, as unstable features may stabilize, change frequently, or vanish entirely.

I am happy to include whatever kind of tests you'd prefer.