### PR TITLE
add no-check flag

### DIFF
--- a/src/DenoWorker.spec.ts
+++ b/src/DenoWorker.spec.ts
@@ -277,6 +277,87 @@ describe('DenoWorker', () => {
             });
         });
 
+        describe('denoNoCheck', async () => {
+            afterEach(() => {
+                jest.clearAllMocks();
+            });
+
+            it('should not include the --no-check flag by default', async () => {
+                const spawnSpy = jest.spyOn(child_process, 'spawn');
+
+                worker = new DenoWorker(echoScript);
+
+                let resolve: any;
+                let promise = new Promise((res, rej) => {
+                    resolve = res;
+                });
+                worker.onmessage = (e) => {
+                    resolve();
+                };
+
+                worker.postMessage({
+                    type: 'echo',
+                    message: 'Hello',
+                });
+
+                await promise;
+
+                const call = spawnSpy.mock.calls[0];
+                const [_deno, args] = call;
+                expect(args).not.toContain('--no-check');
+            });
+
+            it('should not include the --no-check flag by when denoNoCheck is false', async () => {
+                const spawnSpy = jest.spyOn(child_process, 'spawn');
+
+                worker = new DenoWorker(echoScript, { denoNoCheck: false });
+
+                let resolve: any;
+                let promise = new Promise((res, rej) => {
+                    resolve = res;
+                });
+                worker.onmessage = (e) => {
+                    resolve();
+                };
+
+                worker.postMessage({
+                    type: 'echo',
+                    message: 'Hello',
+                });
+
+                await promise;
+
+                const call = spawnSpy.mock.calls[0];
+                const [_deno, args] = call;
+                expect(args).not.toContain('--no-check');
+            });
+
+            it('should include the --no-check flag when denoNoCheck is true', async () => {
+                const spawnSpy = jest.spyOn(child_process, 'spawn');
+
+                worker = new DenoWorker(echoScript, { denoNoCheck: true });
+
+                let resolve: any;
+                let promise = new Promise((res, rej) => {
+                    resolve = res;
+                });
+                worker.onmessage = (e) => {
+                    resolve();
+                };
+
+                worker.postMessage({
+                    type: 'echo',
+                    message: 'Hello',
+                });
+
+                await promise;
+
+                const call = spawnSpy.mock.calls[0];
+                const [_deno, args] = call;
+                expect(args).toContain('--no-check');
+            });
+        });
+
         describe('denoImportMapPath', async () => {
             afterEach(() => {
                 jest.clearAllMocks();

--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -81,6 +81,11 @@ export interface DenoWorkerOptions {
     denoCachedOnly: boolean;
 
     /**
+     * Whether to disable typechecking when starting Deno
+     */
+    denoNoCheck: boolean;
+
+    /**
      * The permissions that the Deno worker should use.
      */
     permissions: {
@@ -183,6 +188,7 @@ export class DenoWorker {
                 denoImportMapPath: '',
                 denoLockFilePath: '',
                 denoCachedOnly: false,
+                denoNoCheck: false,
             },
             options || {}
         );
@@ -274,6 +280,7 @@ export class DenoWorker {
             addOption(runArgs, '--reload', this._options.reload);
             addOption(runArgs, '--unstable', this._options.denoUnstable);
             addOption(runArgs, '--cached-only', this._options.denoCachedOnly);
+            addOption(runArgs, '--no-check', this._options.denoNoCheck);
 
             if (this._options.denoV8Flags.length > 0) {
                 addOption(runArgs, '--v8-flags', this._options.denoV8Flags);


### PR DESCRIPTION
Hello again, thank you for approving my other PRs!

This PR adds support for another flag, one that I think is very promising for performance in situations where type checking is unnecessary.  Specifically, `--no-check` (https://deno.land/manual@v1.16.4/typescript/overview#type-checking) which skips type checking during `deno run`. This is really useful for situations where code has already been type-checked, as it cuts down on startup time substantially (one example I ran went from ~1.5s to <200ms, pretty surprising). 