### PR TITLE
Allow process spawn options to be set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "deno-vm",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "deno-vm",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "license": "MIT",
             "dependencies": {
                 "base64-js": "1.5.1",

--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -142,6 +142,9 @@ export interface DenoWorkerOptions {
         allowHrtime?: boolean;
     };
 
+    /**
+     * Options used to spawn the Deno child process
+     */
     spawnOptions: SpawnOptions;
 }
 

--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -1,7 +1,7 @@
 import { createServer, Server } from 'http';
 import WebSocket, { Server as WSServer } from 'ws';
 import { resolve } from 'path';
-import { ChildProcess, spawn } from 'child_process';
+import { ChildProcess, spawn, SpawnOptions } from 'child_process';
 import {
     serializeStructure,
     deserializeStructure,
@@ -141,6 +141,8 @@ export interface DenoWorkerOptions {
          */
         allowHrtime?: boolean;
     };
+
+    spawnOptions: SpawnOptions;
 }
 
 /**
@@ -192,6 +194,7 @@ export class DenoWorker {
                 denoLockFilePath: '',
                 denoCachedOnly: false,
                 denoNoCheck: false,
+                spawnOptions: {},
             },
             options || {}
         );
@@ -346,13 +349,17 @@ export class DenoWorker {
                 }
             }
 
-            this._process = spawn(this._options.denoExecutable, [
-                'run',
-                ...runArgs,
-                this._options.denoBootstrapScriptPath,
-                connectAddress,
-                ...scriptArgs,
-            ]);
+            this._process = spawn(
+                this._options.denoExecutable,
+                [
+                    'run',
+                    ...runArgs,
+                    this._options.denoBootstrapScriptPath,
+                    connectAddress,
+                    ...scriptArgs,
+                ],
+                this._options.spawnOptions
+            );
             this._process.on('exit', (code: number, signal: string) => {
                 this.terminate();
 

--- a/src/test/env.js
+++ b/src/test/env.js
@@ -1,0 +1,5 @@
+self.onmessage = (e) => {
+    if (e.data.type === 'env') {
+        self.postMessage(Deno.env.get(e.data.name));
+    }
+};


### PR DESCRIPTION
Fixes #30 

At val.town, we need to set an environment variable on each `deno-vm` instance, so we need to pass the `env` option to the `import("child_process").spawn` call.

This PR creates a constructor argument to enable configuring the options used when spawning the Deno process.