### PR TITLE
feat: Support a list of environment variables to allow

### DIFF
--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -121,7 +121,7 @@ export interface DenoWorkerOptions {
          * Whether to allow reading environment variables.
          * Defaults to false.
          */
-        allowEnv?: boolean;
+        allowEnv?: boolean | string[];
 
         /**
          * Whether to allow running Deno plugins.
@@ -133,7 +133,7 @@ export interface DenoWorkerOptions {
          * Whether to allow running subprocesses.
          * Defaults to false.
          */
-        allowRun?: boolean;
+        allowRun?: boolean | string[];
 
         /**
          * Whether to allow high resolution time measurement.


### PR DESCRIPTION
The [permissions you can provide to Deno](https://docs.deno.com/runtime/manual/basics/permissions#permissions-list) have advanced a bit and this brings node-deno-vm's support closer to up to date.

Supports:

- An array of environment variables
- An array of subprocesses that are runnable