### PR TITLE
Allow process.kill to fail with ESRCH

### DIFF
--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -420,7 +420,7 @@ export class DenoWorker {
     }
 
     /**
-     * Terminiates the worker and cleans up unused resources.
+     * Terminates the worker and cleans up unused resources.
      */
     terminate() {
         this._terminated = true;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -29,8 +29,18 @@ function killWindows(pid: number) {
 }
 
 function killUnix(pid: number) {
-    const signal = 'SIGKILL';
-    process.kill(pid, signal);
+    try {
+        const signal = 'SIGKILL';
+        process.kill(pid, signal);
+    } catch (e) {
+        // Allow this call to fail with
+        // ESRCH, which meant that the process
+        // to be killed was already dead.
+        // But re-throw on other codes.
+        if (e.code !== 'ESRCH') {
+            throw e;
+        }
+    }
 }
 
 export interface ExecResult {

--- a/src/test/memory.js
+++ b/src/test/memory.js
@@ -1,0 +1,7 @@
+self.onmessage = (event) => {
+    let arrays = [];
+    for (;;) {
+        arrays.push(new Uint32Array(128));
+        console.log(arrays.length);
+    }
+};


### PR DESCRIPTION
One of the solutions to #32: this makes the `killUnix` command catch an ESRCH error for when the Deno process has terminated unexpectedly so the kill command can't find it.

I don't see a simple way to detect these unexpected exits - `process.exitCode` is null for Node, but the process has exited. So this just makes the other side - the cases where we try to terminate a process that is already terminated - less crashy.