### PR TITLE
Enable socket to be closed

### DIFF
--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -420,6 +420,16 @@ export class DenoWorker {
     }
 
     /**
+     * Closes the websocket, which may allow the process to exit natually.
+     */
+    closeSocket() {
+        if (this._socket) {
+            this._socket.close();
+            this._socket = null;
+        }
+    }
+
+    /**
      * Terminates the worker and cleans up unused resources.
      */
     terminate() {

--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -159,6 +159,7 @@ export class DenoWorker {
     private _server: WSServer;
     private _process: ChildProcess;
     private _socket: WebSocket;
+    private _socketClosed: boolean;
     private _onmessageListeners: OnMessageListener[];
     private _onexitListeners: OnExitListener[];
     private _available: boolean;
@@ -178,6 +179,7 @@ export class DenoWorker {
         this._onexitListeners = [];
         this._pendingMessages = [];
         this._available = false;
+        this._socketClosed = false;
         this._stdout = new Readable();
         this._stdout.setEncoding('utf-8');
         this._stderr = new Readable();
@@ -210,6 +212,11 @@ export class DenoWorker {
         this._server.on('connection', (socket) => {
             if (this._socket) {
                 socket.close();
+                return;
+            }
+            if (this._socketClosed) {
+                socket.close();
+                this._socket = null;
                 return;
             }
             this._socket = socket;
@@ -423,6 +430,7 @@ export class DenoWorker {
      * Closes the websocket, which may allow the process to exit natually.
      */
     closeSocket() {
+        this._socketClosed = true;
         if (this._socket) {
             this._socket.close();
             this._socket = null;
@@ -434,6 +442,7 @@ export class DenoWorker {
      */
     terminate() {
         this._terminated = true;
+        this._socketClosed = true;
         if (this._process && this._process.exitCode === null) {
             // this._process.kill();
             forceKill(this._process.pid);

--- a/src/test/unresolved_promise.js
+++ b/src/test/unresolved_promise.js
@@ -1,0 +1,2 @@
+new Promise(() => {});
+self.postMessage({ type: 'ready' });


### PR DESCRIPTION
This creates the `DenoWorker.closeSocket()` function, that closes the WebSocket, which can keep the process running, even when it's done executing.

## Motivation

At val.town, users can sometimes write scripts that have promises that aren't awaited. We want to let those promises finish, ideally letting Deno exit whenever it thinks it's done.

## Problem

Unresolved promises can cause the DenoWorker to never exit when the websocket is open. Example script:

```
// unresolved.js
new Promise(() => {})
```

When running the script above with `deno run unresolved.js`, it will exit naturally. When using `DenoWorker`, it will keep the process alive.

## Solution

Closing the socket lets Deno properly exit like expected.

