### PR TITLE
feat: Support an object for denoUnstable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "deno-vm",
-    "version": "0.8.4",
+    "version": "0.10.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "deno-vm",
-            "version": "0.8.4",
+            "version": "0.10.2",
             "license": "MIT",
             "dependencies": {
                 "base64-js": "1.5.1",

--- a/src/DenoWorker.spec.ts
+++ b/src/DenoWorker.spec.ts
@@ -274,6 +274,37 @@ describe('DenoWorker', () => {
                 const [_deno, args] = call;
                 expect(args).toContain('--unstable');
             });
+
+            it('should allow fine-grained unstable with an object parameter', async () => {
+                const spawnSpy = jest.spyOn(child_process, 'spawn');
+
+                worker = new DenoWorker(echoScript, {
+                    denoUnstable: {
+                        temporal: true,
+                        broadcastChannel: true,
+                    },
+                });
+
+                let resolve: any;
+                let promise = new Promise((res, rej) => {
+                    resolve = res;
+                });
+                worker.onmessage = (e) => {
+                    resolve();
+                };
+
+                worker.postMessage({
+                    type: 'echo',
+                    message: 'Hello',
+                });
+
+                await promise;
+
+                const call = spawnSpy.mock.calls[0];
+                const [_deno, args] = call;
+                expect(args).toContain('--unstable-temporal');
+                expect(args).toContain('--unstable-broadcast-channel');
+            });
         });
 
         describe('denoCachedOnly', async () => {

--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -59,7 +59,80 @@ export interface DenoWorkerOptions {
     /**
      * Whether to use Deno's unstable features
      */
-    denoUnstable: boolean;
+    denoUnstable:
+        | boolean
+        | {
+              /**
+               * Enable unstable bare node builtins feature
+               */
+              bareNodeBuiltins?: boolean;
+
+              /**
+               *  Enable unstable 'bring your own node_modules' feature
+               */
+              byonm?: boolean;
+
+              /**
+               * Enable unstable resolving of specifiers by extension probing,
+               * .js to .ts, and directory probing.
+               */
+              sloppyImports?: boolean;
+
+              /**
+               * Enable unstable `BroadcastChannel` API
+               */
+              broadcastChannel?: boolean;
+
+              /**
+               * Enable unstable Deno.cron API
+               */
+              cron?: boolean;
+
+              /**
+               * Enable unstable FFI APIs
+               */
+              ffi?: boolean;
+
+              /**
+               * Enable unstable file system APIs
+               */
+              fs?: boolean;
+
+              /**
+               * Enable unstable HTTP APIs
+               */
+              http?: boolean;
+
+              /**
+               * Enable unstable Key-Value store APIs
+               */
+              kv?: boolean;
+
+              /**
+               * Enable unstable net APIs
+               */
+              net?: boolean;
+
+              /**
+               * Enable unstable Temporal API
+               */
+              temporal?: boolean;
+
+              /**
+               * Enable unsafe __proto__ support. This is a security risk.
+               */
+              unsafeProto?: boolean;
+
+              /**
+               * Enable unstable `WebGPU` API
+               */
+              webgpu?: boolean;
+
+              /**
+               * Enable unstable Web Worker APIs
+               */
+              workerOptions?: boolean;
+          };
 
     /**
      * V8 flags to be set when starting Deno
@@ -302,7 +375,20 @@ export class DenoWorker {
             let runArgs = [] as string[];
 
             addOption(runArgs, '--reload', this._options.reload);
-            addOption(runArgs, '--unstable', this._options.denoUnstable);
+            if (this._options.denoUnstable === true) {
+                runArgs.push('--unstable');
+            } else if (this._options.denoUnstable) {
+                for (let [key] of Object.entries(
+                    this._options.denoUnstable
+                ).filter(([_key, val]) => val)) {
+                    runArgs.push(
+                        `--unstable-${key.replace(
+                            /[A-Z]/g,
+                            (m) => '-' + m.toLowerCase()
+                        )}`
+                    );
+                }
+            }
             addOption(runArgs, '--cached-only', this._options.denoCachedOnly);
             addOption(runArgs, '--no-check', this._options.denoNoCheck);
 


### PR DESCRIPTION
Deno has specific unstable APIs that can be enabled individually without adding all of the unstable APIs. This PR allows you to pass an object parameter to denoUnstable with names of APIs. The previous style of passing a boolean is still supported to enable all unstable APIs.