### PR TITLE
chore: Add minimum node requirement (12) to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
         "deno/*",
         "LICENSE",
         "README.md"
-    ]
+    ],
+    "engines": {
+        "node": ">= 12"
+    }
 }


### PR DESCRIPTION
We test this module on Node 12 right now, so this is the minimum supported version. I think this version could be dramatically increased in the near future - v12 is long EOL, v18 is a reasonable minimum. However, this at least makes the requirement explicit for now.