### PR TITLE
Add --location flag support

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -9,7 +9,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest, macOS-latest, windows-latest]
                 node-version: [12.x]
-                deno-version: [1.x]
+                deno-version: [1.40.x]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v1

--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -160,6 +160,12 @@ export interface DenoWorkerOptions {
     denoNoCheck: boolean;
 
     /**
+     * Specify the --location flag, which defines location.href.
+     * This must be a valid URL if provided.
+     */
+    location: string;
+
+    /**
      * The permissions that the Deno worker should use.
      */
     permissions: {
@@ -274,6 +280,7 @@ export class DenoWorker {
                 logStdout: true,
                 logStderr: true,
                 denoUnstable: false,
+                location: undefined,
                 permissions: {},
                 denoV8Flags: [],
                 denoImportMapPath: '',
@@ -391,6 +398,9 @@ export class DenoWorker {
             }
             addOption(runArgs, '--cached-only', this._options.denoCachedOnly);
             addOption(runArgs, '--no-check', this._options.denoNoCheck);
+            if (this._options.location) {
+                addOption(runArgs, '--location', [this._options.location]);
+            }
 
             if (this._options.denoV8Flags.length > 0) {
                 addOption(runArgs, '--v8-flags', this._options.denoV8Flags);


### PR DESCRIPTION
This adds support for the `--location` flag, which specifies the value of `location.href` within deno and also [provides a scope for the Web Storage APIs](https://github.com/denoland/deno/issues/16671).