### PR TITLE
build: Pin Deno to 1.40.x in workflow/publish

### DIFF
--- a/.github/workflows/publish-workflow.yml
+++ b/.github/workflows/publish-workflow.yml
@@ -18,7 +18,7 @@ jobs:
             - name: Use Deno Version ${{ matrix.deno-version }}
               uses: denolib/setup-deno@master
               with:
-                  deno-version: 1.x
+                  deno-version: 1.40.x
             - name: npm install and test
               run: |
                   npm ci


### PR DESCRIPTION
The last release failed because of the updated Deno which was automatically pulled:

https://github.com/casual-simulation/node-deno-vm/actions/runs/8511874789/job/23312344054

We do definitely need to fix this new-deno-version-conflict, but we should get this release out first.