### PR TITLE
Fix usage in Bun (Buffer to string)

### DIFF
--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -309,6 +309,9 @@ export class DenoWorker {
             }
             this._socket = socket;
             socket.on('message', (message) => {
+                if (Buffer.isBuffer(message)) {
+                    message = message.toString();
+                }
                 if (typeof message === 'string') {
                     const structuredData = JSON.parse(message) as Structure;
                     const channel = structuredData.channel;


### PR DESCRIPTION
If the socket's message contents is a buffer (as it is in Bun), convert it to a string