### PR TITLE
Add --unsafely-ignore-certificate-errors flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.12.0
+
+### Date: 4/12/2024
+
+### Changes:
+
+-   Added `unsafelyIgnoreCertificateErrors` option to DenoWorker to let users skip
+    SSL verification.
+
 ## v0.11.0
 
 ### Date: 4/01/2024

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "deno-vm",
-    "version": "0.11.0",
+    "version": "0.12.0",
     "description": "A VM module that provides a secure runtime environment via Deno.",
     "main": "./dist/cjs/index.js",
     "types": "./dist/typings/index.d.ts",

--- a/src/DenoWorker.ts
+++ b/src/DenoWorker.ts
@@ -160,6 +160,12 @@ export interface DenoWorkerOptions {
     denoNoCheck: boolean;
 
     /**
+     * Allow Deno to make requests to hosts with certificate
+     * errors.
+     */
+    unsafelyIgnoreCertificateErrors: boolean;
+
+    /**
      * Specify the --location flag, which defines location.href.
      * This must be a valid URL if provided.
      */
@@ -287,6 +293,7 @@ export class DenoWorker {
                 denoLockFilePath: '',
                 denoCachedOnly: false,
                 denoNoCheck: false,
+                unsafelyIgnoreCertificateErrors: false,
                 spawnOptions: {},
             },
             options || {}
@@ -398,6 +405,11 @@ export class DenoWorker {
             }
             addOption(runArgs, '--cached-only', this._options.denoCachedOnly);
             addOption(runArgs, '--no-check', this._options.denoNoCheck);
+            addOption(
+                runArgs,
+                '--unsafely-ignore-certificate-errors',
+                this._options.unsafelyIgnoreCertificateErrors
+            );
             if (this._options.location) {
                 addOption(runArgs, '--location', [this._options.location]);
             }


### PR DESCRIPTION
This allows users to specify the option `unsafelyIgnoreCertificateErrors` and allow users [to ignore SSL certificate errors](https://github.com/denoland/deno/issues/1371).